### PR TITLE
Updated command for starting Dedalus

### DIFF
--- a/_docs/for-contributors/2017-01-01-building-from-source.md
+++ b/_docs/for-contributors/2017-01-01-building-from-source.md
@@ -203,7 +203,7 @@ npm install
 Now, to run the wallet connected to the Cardano SL in dev-mode, call:
 
 ```
-CARDANO_API=true npm run dev
+npm run dev
 ```
 
 ## Building Cardano SL node for Testing Purpose


### PR DESCRIPTION
This PR updates the command for starting Dedalus. Flag `CARDANO_API=true` is not needed anymore.