### PR TITLE
[CSLD-47] Fixing update mechanism description

### DIFF
--- a/_docs/cardano/2017-01-16-updating.md
+++ b/_docs/cardano/2017-01-16-updating.md
@@ -16,9 +16,7 @@ software updates as well as providing stakeholders with an option to
 vote for hard forks (backwards-incompatible protocol updates) without
 the necessity to introduce any non-protocol-level tools.
 
-We propose to use stake for voting for soft and hard forks and show
-that it is possible to migrate value that exists on the unmaintained
-blockchain to the new blockchain using a modified proof of burn scheme.
+We propose to use stake for voting for soft and hard forks.
 
 ## Update System Model
 
@@ -26,7 +24,7 @@ For CSL, we decided to add some support for protocol updates at
 the protocol layer itself. It introduces some overhead to blockchain
 processing, but has several important benefits:
 
- 1. For each client implementing the protocol, we know it’s the latest
+ 1. For each client implementing the protocol, we know its latest
  version from blockchain.
  2. There is no central entity responsible for maintaining or
  distributing updates, any such update is proposed under implicit or
@@ -46,7 +44,7 @@ Here we consider ways to update the application securely. Protocol
 updates are a separate issue which is covered in the relevant section
 of this document.
 
-For an update to be applied, it's proposal needs be approved first.
+For an update to be applied, its proposal needs be approved first.
 Update proposal can be approved if either one of two agreements is reached:
 
  1. **Explicit agreement**: it has positive votes from majority of total stake
@@ -65,7 +63,7 @@ stakeholders should agree on whether to consider this update trusted.
 ### Implicit Agreement
 
 The fact that stakeholders are responsible for system updates does not
-restrict us to the system where every single update requires a signature
+restrict us to a system where every single update requires a signature
 from the majority of stake. We can introduce the concept of an **implicit
 agreement**.
 
@@ -77,7 +75,7 @@ the update — they should vote either for or against it.
 
 IOHK will maintain a single official client. But there is also room for
 third-party alternative clients maintained by the community. One requires
-to collect enough signatures from stakeholders to publish their system
+enough collected signatures from stakeholders to publish their system
 update, which may be not an «update», but a different client developed
 from scratch, or a fork of the official client. As long as this update has
 enough signatures from stakeholders, the network considers it trusted, and
@@ -96,9 +94,11 @@ Also, it’s interesting to note that the update itself does not require
 a secure and trusted channel to be used for delivery, as it is signed
 with some known in advance and trusted key (or set of keys).
 
-Application updates are prepared with bsdiff and applied either directly
-or via an installer. We're considering migrating to courgette in the
-future.
+Application updates are prepared with
+[bsdiff](https://github.com/mendsley/bsdiff) and applied either directly
+or via an installer. We're considering migrating to
+[courgette](http://dev.chromium.org/developers/design-documents/software-updates-courgette)
+in the future.
 
 ## Protocol Update
 
@@ -177,6 +177,8 @@ crowd, so his chain is shorter). A simple resolution rule could go like this: if
 95% of the latest 2016 blocks have a newer block version, the blocks with the
 older version are rejected.
 
+> **Block version** here and later has the same meaning as the **protocol version**.
+
 It may seem unclear why we would like to make some block version invalid at some
 moment. The key insight here is that a new feature is actually a restriction on
 what we had had previously. For example, currently we have plain old
@@ -209,7 +211,9 @@ In our implementation, a block version can exist in the following states:
 * **Adopted**, when the soft fork resolution rule (see below) for a confirmed
   block version is triggered.
 * **Confirmed**, when there is an update proposal that contains a confirmed
-  version of the software and this block version. Note that "confirmed version of the software" is a technical term defined [elsewhere](/cardano/update-mechanism/#soft-fork-updates). If there are multiple block
+  version of the software and this block version. Note that "confirmed version of the software"
+  is a technical term defined [elsewhere](/cardano/update-mechanism/#soft-fork-updates).
+  If there are multiple block
   versions where corresponding software is confirmed, but these versions
   aren't adopted, we call them **competing**. For instance, there might be
   versions `2.0.0`, `2.0.1`, `1.2.0`, `1.2.1`, `1.1.1` and `1.1.2`, with the last
@@ -235,8 +239,10 @@ The soft fork resolution rule works as follows:
   gets *adopted*. If more than one version has ≥ 75%, we take one of them
   deterministically.
 
-Note that new block versions can be adopted only at the beginning of an epoch,
-so all blocks in an epoch have the same block version.
+Note that new block versions can be adopted only at the beginning of an epoch.
+But it's wrong to assume that all blocks in an epoch have the same block version.
+After block version is adopted, another block version can become competing and
+some nodes may create blocks with this new version.
 
 So, gathering everything up:
 

--- a/_docs/cardano/2017-01-16-updating.md
+++ b/_docs/cardano/2017-01-16-updating.md
@@ -6,6 +6,7 @@ group: cardano
 visible: true
 ---
 [//]: # (Reviewed at d0d6c2fedefb642744a24b4b0a6d8d7ad11532f6)
+[//]: # (Updated at 6b5eda44e5942599a9781e5ad3f51eb820665b83)
 
 # Research Overview
 
@@ -45,8 +46,13 @@ Here we consider ways to update the application securely. Protocol
 updates are a separate issue which is covered in the relevant section
 of this document.
 
-For an update to be applied, at least the majority of stake should put
-their signatures on it.
+For an update to be applied, it's proposal needs be approved first.
+Update proposal can be approved if either one of two agreements is reached:
+
+ 1. **Explicit agreement**: it has positive votes from majority of total stake
+ (i. e. strictly greater than `50%`).
+ 2. **Implicit agreement**: it has positive votes from more stake than negative
+ votes ﻿⁠⁠⁠and﻿⁠⁠⁠ it has been in blockchain for at least `U` slots.
 
 This approach seems to fit naturally into the CSL model, as in a
 PoS cryptocurrency every stakeholder is responsible for maintaining the
@@ -60,25 +66,19 @@ stakeholders should agree on whether to consider this update trusted.
 
 The fact that stakeholders are responsible for system updates does not
 restrict us to the system where every single update requires a signature
-from the majority of stake. We can introduce the concept of an implicit
-agreement.
+from the majority of stake. We can introduce the concept of an **implicit
+agreement**.
 
-An update has to have at least T% of the stake signatures to be
+An update has to have at least `T%` of the stake signatures to be
 published on the blockchain. It is not enough for stakeholders to sign
-the update — they should vote either for or against it. The update is
-considered confirmed and should be adopted by nodes if all of the
-following conditions are met:
-
- + At least 50% of the stake voted for or against the software update.
- + The majority of the stake voted for the update.
- + It has been on the blockchain for U slots.
+the update — they should vote either for or against it.
 
 ### Incorporation of Alternative Clients
 
 IOHK will maintain a single official client. But there is also room for
 third-party alternative clients maintained by the community. One requires
 to collect enough signatures from stakeholders to publish their system
-update, which may be not an "update", but a different client developed
+update, which may be not an «update», but a different client developed
 from scratch, or a fork of the official client. As long as this update has
 enough signatures from stakeholders, the network considers it trusted, and
 it is updated via the same mechanisms as the official client.
@@ -109,8 +109,8 @@ new version blocks are still compatible with old version clients.
 A hard fork is one that doesn’t maintain backward compatibility with
 the previous version.
 
-BIP-99 provides excellent criteria to distinguish between these two
-fork types:
+[BIP-99](https://github.com/bitcoin/bips/blob/ed283b05b332b85b6fd683be3a5d73fab6c15554/bip-0099.mediawiki)
+provides excellent criteria to distinguish between these two fork types:
 
 * A **soft fork** introduces new rules, or restrictions, on blocks. That way,
   everything that was previously invalid remains invalid, while some blocks

--- a/_docs/cardano/2017-01-16-updating.md
+++ b/_docs/cardano/2017-01-16-updating.md
@@ -177,7 +177,7 @@ crowd, so his chain is shorter). A simple resolution rule could go like this: if
 95% of the latest 2016 blocks have a newer block version, the blocks with the
 older version are rejected.
 
-> **Block version** here and later has the same meaning as the **protocol version**.
+**NOTE**: **block version** here and later has the same meaning as the **protocol version**.
 
 It may seem unclear why we would like to make some block version invalid at some
 moment. The key insight here is that a new feature is actually a restriction on
@@ -198,7 +198,7 @@ deprecated).
 
 We also cannot bluntly accept all blocks with a version that is higher than the one
 currenlty adopted, since in our implementation every block has a field called
-[`attributes`](https://github.com/input-output-hk/cardano-sl/blob/db0746e4693b3be645959d42d808ced3ee03f402/src/Pos/Types/Block/Types.hs#L87)
+[attributes](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Types/Block/Types.hs#L87)
 which is used for storing auxiliary information. An attacker could claim she
 uses a higher version of the protocol and generate a block whose `attributes`
 would be polluted with meaningless keys. If we accepted it, it would bloat
@@ -239,8 +239,10 @@ The soft fork resolution rule works as follows:
   gets *adopted*. If more than one version has ≥ 75%, we take one of them
   deterministically.
 
-Note that new block versions can be adopted only at the beginning of an epoch.
-But it's wrong to assume that all blocks in an epoch have the same block version.
+Note that adopted block version can't be changed during epoch (only between epochs),
+so all blocks in an epoch are verified according to the same rules
+(because rules are defined by adopted block version).
+But it's wrong to assume that _all_ blocks in an epoch have the same block version.
 After block version is adopted, another block version can become competing and
 some nodes may create blocks with this new version.
 

--- a/_docs/technical/2017-01-04-updater.md
+++ b/_docs/technical/2017-01-04-updater.md
@@ -38,9 +38,9 @@ duration). Specifically, `upBlockVersion` is used to signify that a proposal
 performs such changes; if `upBlockVersion` is greater than the last used
 block version, the changes from `upBlockVersionData` will be applied.
 
-`upBlockVersionData` has the
-type
-[`BlockVersionData`](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Update/Core/Types.hs#L131-L142). Its fields are described below:
+`upBlockVersionData` has the type
+[`BlockVersionData`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/update/Pos/Update/Core/Types.hs#L135-L149).
+Its fields are described below:
 
   * `bvdScriptVersion` – a script language version used to validate script
     transactions. If the proposal increases `upBlockVersion`, it must also
@@ -52,14 +52,15 @@ type
     increase the block size limit more than twofold compared to the previous
     limit.
 
+  * `bvdMaxTxSize` – transaction size limit
+    (in bytes, [currently 4096](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/core/constants-prod.yaml#L9)).
+
 The checks described above are made
 in
-[`verifyNextBVData`](https://github.com/input-output-hk/cardano-sl/blob/f77917a6a6a393bb3ef158500c147181fe21ed39/src/Pos/Update/Poll/Logic/Base.hs#L194-L221).
-
+[`verifyNextBVData`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Poll/Logic/Base.hs#L231).
 In addition, there are some fields that are unused right now, but will be used
 in the future. Their meaning is briefly described below:
 
-  * `bvdMaxTxSize` – transaction size limit (in bytes).
 
   * `bvdMpcThd` – eligibility threshold for MPC.
 
@@ -68,11 +69,9 @@ in the future. Their meaning is briefly described below:
   * `bvdUpdateVoteThd` – portion of total stake necessary to vote for or
     against an update.
 
-  * `bvdUpdateProposalThd` – number of slots after which an update is
-    implicitly approved (unless it has more negative votes than positive).
-
-[//]: TODO: ^ is probably incorrect. See this: https://github.com/input-output-hk/cardano-docs.iohk.io/issues/93
-[//]: TODO: But I don't know correct description
+  * `bvdUpdateProposalThd` – portion of total stake such that block containing
+    `UpdateProposal` must contain positive votes for this proposal
+    from stakeholders owning at least this amount of stake.
 
   * `bvdUpdateImplicit` – number of slots after which an update is implicitly
     approved (unless it has more negative votes than positive).
@@ -81,13 +80,11 @@ in the future. Their meaning is briefly described below:
     of issuers of blocks with some block version is bigger than this portion,
     this block version is adopted.
 
-## Proposal Accumulation
+## Mempool Structure
 
-To vote for proposal nodes should send their
-[`votes`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/update/Pos/Update/Core/Types.hs#L242-L253).
-Proposals are stored in a mempool (even if they don't have enough votes for inclusion into blocks,
-this way votes can be collected automatically) or gathered from the blockchain in
-order to figure out which proposal is adopted. No matter whether a change in
+`MemPool` consists of votes and proposals. Apart from that `MemState` contains tip,
+slot and `PollModifier` corresponding to `MemPool` (and to current `GState`, i. e.
+to application of `MemPool` to `GState`). No matter whether a change in
 proposal state comes from the network/mempool, or from loading
 the blockchain, `PollModifier` is stored together with mempool and it represents
 modification of global state which will be done if one applies mempool.
@@ -97,20 +94,47 @@ modification of global state which will be done if one applies mempool.
 As nodes deserialize
 [payloads of update system messages](/technical/protocols/binary-protocols/#update-system),
 they modify mempool as implemented
-[here](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Update/MemState/Functions.hs#L40).
+[here](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/MemState/Functions.hs#L29).
 
-[//]: TODO: what to say about votes?
+`MemPool` is updated in three cases:
+
+  1. **When new proposal/vote is received**. In this case one of the
+  [`process*`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Logic/Local.hs#L94)
+  functions is called which in turn calls
+  [`verifyAndApplyUSPayload`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Poll/Logic/Apply.hs#L63)
+  and then updates current `PollModifier` and `MemPool`.
+  2. **When new slot starts**. In this case some data in `MemPool` may become invalid.
+  In fact, it happens only when epoch changes. That's because stable stake distribution
+  changes and some votes may have not enough stake for inclusion, for example.
+  It's done in
+  [`processNewSlot`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Logic/Local.hs#L208)
+  function.
+  3. **When `GState` is updated**. It is called
+  [`usNormalize`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Logic/Local.hs#L177).
+  Some data may become invalid as a result of block(s) application or rollback. For instance,
+  we have proposal in memory, apply block with this proposal and it becomes invalid
+  (because it's already in block). We should drop such proposal. Or we have vote for
+  proposal from some block, then rollback of this block happens and vote becomes no
+  longer valid. It is implemented by applying all local data to empty state ignoring
+  all data which is no longer valid.
+
+### Proposal and Votes Accumulation
+
+To vote for proposal nodes should send their
+[`votes`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/update/Pos/Update/Core/Types.hs#L242-L253).
+Proposals and votes are stored in a mempool (even if proposals don't have enough
+votes for inclusion into blocks, this way votes can be collected automatically)
+or gathered from the blockchain in order to figure out which proposal is adopted.
 
 ## Interaction With the Database
 
 In order to verify update system data, we have to get this data from the
-global state (database). To provide such interface, a [well-documented
-set of typeclasses is
-presented](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Update/Poll/Class.hs).
-These two type classes are used not only for DB interaction, but also to
+global state (database). To provide such interface, a well-documented type class
+[`MonadPollRead`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Poll/Class.hs#L30)
+is presented. This type class is used not only for DB interaction, but also to
 take mempool into account when we are processing data received from the network.
-It is important that their implementation relies on functions found in
-[Pos.DB.GState.Update](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/DB/GState/Update.hs).
+It is important that its implementation relies on functions found in
+[`Pos.Update.DB`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/DB.hs).
 
 ## Core Types
 
@@ -123,41 +147,69 @@ for more information.
 ## Update Proposal Approval
 
 A very important part of implementation of the update mechanism is
-the part that works with genesis blocks for epochs and applies updates.
+the part that works with genesis blocks for epochs.
 This logic resides
-[in this well-documented function](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Update/Poll/Logic/Softfork.hs#L67).
+[in this well-documented function](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Poll/Logic/Softfork.hs#L68).
 We explain terminology related to this process below.
 
 ### Threshold
 
 `softforkResolutionThreshold` is a threshold (referred to as «threshold»
-in the code) which, for an update proposal with version `v`, says ???
+in the code), which allows to define stable stake for each stakeholder
+as their stake `k` blocks ago. See more detailed description in
+[research overview](cardano/update-mechanism/#soft-fork-updates).
 
-[//]: TODO: IDK how to link threshold & predicate & block version here
-[//]: Because IDK what for this threshold is.
 
-### Well-formed Proposal
+### Proposal states
 
-A proposal is called “well-formed” if the following conditions are met:
+**Software** version (which can be found in proposals in blocks)
+can be in one of the states described bellow.
 
-[//]: TODO: say it in different way?
+#### Undecided
 
- + It is correctly formed, including necessary cryptographic signatures.
- + Its version is greater or equal to the currently adopted proposal
-   (see below).
+It means that update proposal with given **software** version is contained in
+one of the blocks, but it doesn't have `50%` votes (here `50%` means that total
+stake of voters for/against proposal relative to total stake of all stakeholders
+in system) for/against it and implicit agreement rule hasn't been triggered yet.
 
-### Confirmed Proposal
+[//]: TODO: **Important remark:** when we are talking about stake, we need to be clear about
+[//]: TODO: which stake distribution we are talking about. For each epoch we know stable distribution
+[//]: TODO: for this epoch. It used in leaders selection (follow-the-satoshi) and also in many other
+[//]: TODO: cases. Stable distribution is distribution as it was ﻿⁠⁠⁠⁠2k﻿⁠⁠⁠⁠ slots before the end of epoch.
+[//]: TODO: To calculate stake of votes for proposal ﻿⁠⁠⁠⁠p﻿⁠⁠⁠⁠ we use stake distribution as per epoch in
+[//]: TODO: which ﻿⁠⁠⁠⁠p﻿⁠⁠⁠⁠ was added to blocks. I. e. distribution which was ﻿⁠⁠⁠⁠2k﻿⁠⁠⁠⁠ slots before the
+[//]: TODO: end of that epoch. This ensures that nobody can transfer his funds to another address
+[//]: TODO: and vote from that address to increase total stake of voters.
+[//]: TODO:
+[//]: TODO: **Another important remark:** when we are talking about stake, it's also important to be
+[//]: TODO: clear whether we consider delegated stake. I. e. if Alice delegated to Bob, do we consider
+[//]: TODO: that Alice's funds belong to Bob or Alice? When we use stake for votes, we consider delegated
+[//]: TODO: stake, i. e. we consider that Alice's funds belong to Bob. Note that here we consider
+[//]: TODO: only heavyweight delegation. I hope it's covered in documentation, but I am not sure.
 
-An acceptable proposal is called “confirmed” if it was voted for by the
-majority of stake, but `softforkResolutionThreshold` predicate isn't yet
-true for it.
+#### Approved
 
-### Approved Proposal
+It means that proposal has more than `50%` votes for it or it was added to block long ago
+(according to implicit agreement rule) and it has more positive votes than negative
+(comparison by stake of course).
 
-A confirmed proposal is said to be “adopted” if its
-`softforkResolutionThreshold` predicate is true for it. For each
-blockchain state, there is exactly one adopted version. Blocks are
-checked taking into consideration the currently adopted version.
+#### Rejected
+
+A proposal is called **rejected** if that proposal has more than `50%` votes against it or
+it was added to block long ago (according to implicit agreement rule) and it has more
+negative votes than positive (again, comparison by stake).
+
+#### Confirmed
+
+An **approved** proposal is called **confirmed** if at least `k` blocks ago proposal
+became **Approved**. At this point we can be sure that proposal won't become **rejected**,
+because rollbacks with depth more than `k` aren't possible.
+
+#### Discarded
+
+A **rejected** proposal is called **discarded** if at least `k` blocks ago proposal
+became **Rejected**. At this point we can be sure that proposal won't become approved,
+because rollbacks with depth more than `k` aren't possible.
 
 ## Download New Version
 

--- a/_docs/technical/2017-01-04-updater.md
+++ b/_docs/technical/2017-01-04-updater.md
@@ -32,14 +32,14 @@ section; soft forks (or software updates) are fully implemented.
 ## Fields Updatable with a Soft Fork
 
 An
-[`UpdateProposal`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/update/Pos/Update/Core/Types.hs#L99-L109) contains
+[UpdateProposal](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/update/Pos/Update/Core/Types.hs#L99-L109) contains
 fields for changing some parameters used by Cardano SL (for instance, slot
 duration). Specifically, `upBlockVersion` is used to signify that a proposal
 performs such changes; if `upBlockVersion` is greater than the last used
 block version, the changes from `upBlockVersionData` will be applied.
 
 `upBlockVersionData` has the type
-[`BlockVersionData`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/update/Pos/Update/Core/Types.hs#L135-L149).
+[BlockVersionData](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/update/Pos/Update/Core/Types.hs#L135-L149).
 Its fields are described below:
 
   * `bvdScriptVersion` – a script language version used to validate script
@@ -53,11 +53,12 @@ Its fields are described below:
     limit.
 
   * `bvdMaxTxSize` – transaction size limit
-    (in bytes, [currently 4096](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/core/constants-prod.yaml#L9)).
+    (in bytes, [currently 4096](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/core/constants-prod.yaml#L9)),
+    limits size of [TxAux](/technical/protocols/binary-protocols/#transaction-auxilary)
 
 The checks described above are made
 in
-[`verifyNextBVData`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Poll/Logic/Base.hs#L231).
+[verifyNextBVData](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Poll/Logic/Base.hs#L231).
 In addition, there are some fields that are unused right now, but will be used
 in the future. Their meaning is briefly described below:
 
@@ -86,7 +87,7 @@ in the future. Their meaning is briefly described below:
 slot and `PollModifier` corresponding to `MemPool` (and to current `GState`, i. e.
 to application of `MemPool` to `GState`). No matter whether a change in
 proposal state comes from the network/mempool, or from loading
-the blockchain, `PollModifier` is stored together with mempool and it represents
+the blockchain, `PollModifier` represents
 modification of global state which will be done if one applies mempool.
 
 ### Updating the Mempool
@@ -99,18 +100,18 @@ they modify mempool as implemented
 `MemPool` is updated in three cases:
 
   1. **When new proposal/vote is received**. In this case one of the
-  [`process*`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Logic/Local.hs#L94)
+  [process*](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Logic/Local.hs#L94)
   functions is called which in turn calls
-  [`verifyAndApplyUSPayload`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Poll/Logic/Apply.hs#L63)
+  [verifyAndApplyUSPayload](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Poll/Logic/Apply.hs#L63)
   and then updates current `PollModifier` and `MemPool`.
   2. **When new slot starts**. In this case some data in `MemPool` may become invalid.
   In fact, it happens only when epoch changes. That's because stable stake distribution
   changes and some votes may have not enough stake for inclusion, for example.
   It's done in
-  [`processNewSlot`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Logic/Local.hs#L208)
+  [processNewSlot](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Logic/Local.hs#L208)
   function.
   3. **When `GState` is updated**. It is called
-  [`usNormalize`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Logic/Local.hs#L177).
+  [usNormalize](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Logic/Local.hs#L177).
   Some data may become invalid as a result of block(s) application or rollback. For instance,
   we have proposal in memory, apply block with this proposal and it becomes invalid
   (because it's already in block). We should drop such proposal. Or we have vote for
@@ -121,7 +122,7 @@ they modify mempool as implemented
 ### Proposal and Votes Accumulation
 
 To vote for proposal nodes should send their
-[`votes`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/update/Pos/Update/Core/Types.hs#L242-L253).
+[votes](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/update/Pos/Update/Core/Types.hs#L242-L253).
 Proposals and votes are stored in a mempool (even if proposals don't have enough
 votes for inclusion into blocks, this way votes can be collected automatically)
 or gathered from the blockchain in order to figure out which proposal is adopted.
@@ -130,18 +131,18 @@ or gathered from the blockchain in order to figure out which proposal is adopted
 
 In order to verify update system data, we have to get this data from the
 global state (database). To provide such interface, a well-documented type class
-[`MonadPollRead`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Poll/Class.hs#L30)
+[MonadPollRead](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Poll/Class.hs#L30)
 is presented. This type class is used not only for DB interaction, but also to
 take mempool into account when we are processing data received from the network.
 It is important that its implementation relies on functions found in
-[`Pos.Update.DB`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/DB.hs).
+[Pos.Update.DB](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/DB.hs).
 
 ## Core Types
 
 Core types are mentioned in the Binary protocols document. Those types
 reflect the concepts from the research section in a straightforward way.
-Please refer to the [core types
-module](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Update/Core/Types.hs)
+Please refer to the
+[core types module](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/update/Pos/Update/Core/Types.hs)
 for more information.
 
 ## Update Proposal Approval
@@ -154,20 +155,19 @@ We explain terminology related to this process below.
 
 ### Threshold
 
-`softforkResolutionThreshold` is a threshold (referred to as «threshold»
-in the code), which allows to define stable stake for each stakeholder
-as their stake `k` blocks ago. See more detailed description in
-[research overview](cardano/update-mechanism/#soft-fork-updates).
-
+Suppose there is a block version `X`. And there are blocks with version `X`
+created in slots `S` (`S` is a set of slots). If total relative stake of
+leaders of all slots in `S` is ≥ `softforkResolutionThreshold`
+(referred to as «threshold» in the code) then `X` becomes adopted.
+See more detailed description in [research overview](cardano/update-mechanism/#soft-fork-updates).
 
 ### Proposal states
 
-**Software** version (which can be found in proposals in blocks)
-can be in one of the states described bellow.
+Update proposal can be in one of the states described below.
 
 #### Undecided
 
-It means that update proposal with given **software** version is contained in
+It means that update proposal is contained in
 one of the blocks, but it doesn't have `50%` votes (here `50%` means that total
 stake of voters for/against proposal relative to total stake of all stakeholders
 in system) for/against it and implicit agreement rule hasn't been triggered yet.
@@ -214,10 +214,10 @@ because rollbacks with depth more than `k` aren't possible.
 ## Download New Version
 
 In the
-[Pos.Update.Download](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Update/Download.hs)
+[Pos.Update.Download](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update/Download.hs)
 module, the following algorithms are implemented. Downloaded updates are
 applied using a tool called
-[launcher](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/launcher/Main.hs)
+[launcher](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/launcher/Main.hs).
 
 ### Download Confirmed Update
 

--- a/_docs/technical/2017-01-04-updater.md
+++ b/_docs/technical/2017-01-04-updater.md
@@ -6,19 +6,20 @@ group: technical
 visible: true
 ---
 [//]: # (Reviewed at e1d0f9fb37a3f1378341716916f0321fb55698df)
+[//]: # (Updated at 6b5eda44e5942599a9781e5ad3f51eb820665b83)
 
 # Implementation Overview
 
 Implementation of the update system can be found in the
-[Pos.Update](https://github.com/input-output-hk/cardano-sl/tree/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Update)
+[Pos.Update](https://github.com/input-output-hk/cardano-sl/tree/6b5eda44e5942599a9781e5ad3f51eb820665b83/src/Pos/Update)
 family of modules. The general approach to implementation is the same as
 in other subsystems of CSL, such as Txp, Ssc and Delegation. The update
 system has the global state, stored in the database. The global state can be
 unambiguously derived from the information that is in the blockchain. The local
 state, sometimes referred to as “mempool”, is stored in the memory.
 The mempool is used for data transfer and inclusion of transferred data into
-blocks. The network protocol (built with standard [Inv/Req/Data
-pattern](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Communication/Relay.hs))
+blocks. The network protocol (built with standard
+[Inv/Req/Data pattern](https://github.com/input-output-hk/cardano-sl/tree/6b5eda44e5942599a9781e5ad3f51eb820665b83/infra/Pos/Communication/Relay))
 is described in
 [Application-level document](/technical/protocols/csl-application-level/)
 with the binary protocol described in
@@ -31,7 +32,7 @@ section; soft forks (or software updates) are fully implemented.
 ## Fields Updatable with a Soft Fork
 
 An
-[`UpdateProposal`](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Update/Core/Types.hs#L97-L108) contains
+[`UpdateProposal`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/update/Pos/Update/Core/Types.hs#L99-L109) contains
 fields for changing some parameters used by Cardano SL (for instance, slot
 duration). Specifically, `upBlockVersion` is used to signify that a proposal
 performs such changes; if `upBlockVersion` is greater than the last used
@@ -70,6 +71,9 @@ in the future. Their meaning is briefly described below:
   * `bvdUpdateProposalThd` – number of slots after which an update is
     implicitly approved (unless it has more negative votes than positive).
 
+[//]: TODO: ^ is probably incorrect. See this: https://github.com/input-output-hk/cardano-docs.iohk.io/issues/93
+[//]: TODO: But I don't know correct description
+
   * `bvdUpdateImplicit` – number of slots after which an update is implicitly
     approved (unless it has more negative votes than positive).
 
@@ -79,12 +83,14 @@ in the future. Their meaning is briefly described below:
 
 ## Proposal Accumulation
 
-Proposals are stored in a mempool or gathered from the blockchain in
-order to figure out which proposal is adopted, and whether or not the current
-node has to participate in voting. No matter whether a change in
+To vote for proposal nodes should send their
+[`votes`](https://github.com/input-output-hk/cardano-sl/blob/6b5eda44e5942599a9781e5ad3f51eb820665b83/update/Pos/Update/Core/Types.hs#L242-L253).
+Proposals are stored in a mempool (even if they don't have enough votes for inclusion into blocks,
+this way votes can be collected automatically) or gathered from the blockchain in
+order to figure out which proposal is adopted. No matter whether a change in
 proposal state comes from the network/mempool, or from loading
-the blockchain, it is stored in the `PollModifier` data structure and applied
-appropriately.
+the blockchain, `PollModifier` is stored together with mempool and it represents
+modification of global state which will be done if one applies mempool.
 
 ### Updating the Mempool
 
@@ -93,14 +99,17 @@ As nodes deserialize
 they modify mempool as implemented
 [here](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Update/MemState/Functions.hs#L40).
 
+[//]: TODO: what to say about votes?
+
 ## Interaction With the Database
 
 In order to verify update system data, we have to get this data from the
 global state (database). To provide such interface, a [well-documented
 set of typeclasses is
 presented](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Update/Poll/Class.hs).
-It is important that their implementation relies on functions found
-in
+These two type classes are used not only for DB interaction, but also to
+take mempool into account when we are processing data received from the network.
+It is important that their implementation relies on functions found in
 [Pos.DB.GState.Update](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/DB/GState/Update.hs).
 
 ## Core Types
@@ -111,7 +120,7 @@ Please refer to the [core types
 module](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Update/Core/Types.hs)
 for more information.
 
-## Update Proposal Adoption
+## Update Proposal Approval
 
 A very important part of implementation of the update mechanism is
 the part that works with genesis blocks for epochs and applies updates.
@@ -119,15 +128,19 @@ This logic resides
 [in this well-documented function](https://github.com/input-output-hk/cardano-sl/blob/22360aa45e5dd82d0c87872d8530217fc3d08f4a/src/Pos/Update/Poll/Logic/Softfork.hs#L67).
 We explain terminology related to this process below.
 
-### `softforkResolutionThreshold` Predicate
+### Threshold
 
-`softforkResolutionThreshold` is a predicate (referred to as “threshold”
-in the code) which, for an update proposal with version `v`, says that
-it is a version of software ran by the network.
+`softforkResolutionThreshold` is a threshold (referred to as «threshold»
+in the code) which, for an update proposal with version `v`, says ???
 
-### Acceptable Proposal
+[//]: TODO: IDK how to link threshold & predicate & block version here
+[//]: Because IDK what for this threshold is.
 
-A proposal is called “acceptable” if the following conditions are met:
+### Well-formed Proposal
+
+A proposal is called “well-formed” if the following conditions are met:
+
+[//]: TODO: say it in different way?
 
  + It is correctly formed, including necessary cryptographic signatures.
  + Its version is greater or equal to the currently adopted proposal
@@ -139,7 +152,7 @@ An acceptable proposal is called “confirmed” if it was voted for by the
 majority of stake, but `softforkResolutionThreshold` predicate isn't yet
 true for it.
 
-### Adopted Proposal
+### Approved Proposal
 
 A confirmed proposal is said to be “adopted” if its
 `softforkResolutionThreshold` predicate is true for it. For each


### PR DESCRIPTION
This PR attempts to fix strange places in description of Update mechanism. I followed @gromakovsky message from issue [CSLD-47](https://issues.serokell.io/issue/CSLD-47). Not all things are fixed. I left some TODO's. And I need somebody to comment and to say something. Here few words from me about what can be improved and fixed:


> We have words like ﻿⁠⁠⁠**confirmed**﻿⁠⁠⁠, ﻿⁠⁠⁠**adopted**﻿⁠⁠⁠, **﻿⁠⁠⁠approved**﻿⁠⁠⁠, **﻿⁠⁠⁠competing**﻿⁠⁠⁠ and so on.

I think definition of such words should be moved somewhere earlier. I see **adopted** and **confirmed** only at the end of _Research Overview_. And later we repeat some of these definitions in _Implementation Overview_ but we define them in a wrong way later.

> Layer which covers all rules in detail.

I see this layer is probably still described poorly. But I don't know where is appropriate place for this layer and how I can collect all rules in effective manner.

> Soft fork updates﻿⁠⁠⁠ section is bad in general and partially incorrect, but it's discussed separately.

I didn't notice such discussions and fixes of it as a consequence :( So this section is probably still pretty bad. Correct me if I'm wrong.

> Implicit agreement

It's a separate section (though we have **Explicit agreement** and **Implicit agreement**). But we don't have section for **Explicit agreement**. And there're some useful words in **Implicit agreement** section but structure of mentioning and describing agreements makes me sad. I've tried to fix this but still don't like it. Suggestions are welcome.